### PR TITLE
feat: 비공개 게시글에 대한 렌더링 핸들 로직 수정

### DIFF
--- a/client/components/post/Skeleton/index.tsx
+++ b/client/components/post/Skeleton/index.tsx
@@ -2,12 +2,10 @@ import React from "react";
 import PostContentSkeleton from "components/post/PostContent/Skeleton";
 import PostTopSkeleton from "components/post/PostTop/Skeleton";
 import styles from "./styles.module.scss";
-import Header from "components/Header";
 
 const PostSkeleton = () => {
   return (
     <>
-      <Header />
       <div className={styles.PostSkeletonWrapper}>
         <PostTopSkeleton />
         <PostContentSkeleton />

--- a/client/pages/post/[id].tsx
+++ b/client/pages/post/[id].tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps, GetStaticPropsContext } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { dehydrate, QueryClient } from "react-query";
 import { getAllPostsId, getOnePostAPI } from "services/post";
 import CommentForm from "components/post/CommentForm";
@@ -26,20 +26,32 @@ import { PostContainer } from "context/postContext";
 const Post = () => {
   const router = useRouter();
 
-  const { data: userInfo, isLoading: userInfoLoadLoading } = useGetUserInfo();
+  const [adminValidationForNotPublicPost, setAdminValidationForNotPublicPost] =
+    useState(false);
+
+  const { data: userInfo } = useGetUserInfo();
   const { data } = useGetOnePost(Number(router.query.id));
 
   const Post = data?.mainPost;
 
   useEffect(() => {
-    if (userInfoLoadLoading) return;
-    if (!IsAdmin(userInfo) && Post?.isPublic === 0) {
+    if (Post?.isPublic) return;
+
+    if (IsAdmin(userInfo)) {
+      setAdminValidationForNotPublicPost(true);
+    } else {
       alert(MESSAGE.NOT_READY_POST);
       router.replace("/");
     }
-  }, [Post?.isPublic, router, userInfo, userInfoLoadLoading]);
+  }, [Post?.isPublic, userInfo]);
 
   if (router.isFallback) return <PostSkeleton />;
+
+  if (!Post?.isPublic) {
+    if (!adminValidationForNotPublicPost) {
+      return <PostSkeleton />;
+    }
+  }
 
   return (
     <>


### PR DESCRIPTION
- 관리자 검증 과정 중간에 콘텐츠가 렌더링 되지 않도록 수정
- 비공개 게시글의 경우 빌드타임에 만들게 되는 HTML 파일에 게시글 정보가 들어가지 않도록 수정